### PR TITLE
Fix WE 1.6 layout loading and multi-layout restore

### DIFF
--- a/BelzontWE/Systems/WEPreCullingSystem.cs
+++ b/BelzontWE/Systems/WEPreCullingSystem.cs
@@ -1,4 +1,4 @@
-﻿using Colossal.Entities;
+using Colossal.Entities;
 using Colossal.Mathematics;
 using Game.Prefabs;
 using Game.Rendering;
@@ -218,51 +218,45 @@ namespace BelzontWE
                 var isDependent = (cullInfo.m_Mask & Game.Common.BoundsMask.NormalLayers) == 0 && (!m_meshesLkp.TryGetBuffer(entity, out var buff) || buff.IsEmpty);
                 if (isDependent)
                 {
-                    if (m_dependentsLkp.HasBuffer(entity))
-                    {
-                        m_CommandBuffer.RemoveComponent<WEDependantRendering>(index, entity);
-                    }
                     return;
                 }
-                else
-                {
-                    if (!m_dependentsLkp.HasBuffer(entity))
-                    {
-                        CatalogSubObjects(index, entity);
-                    }
-
-                }
-
                 var passed = (cullingAction.m_Flags & PreCullingFlags.PassedCulling) != 0;
+                var hasAnyWeLayout = false;
 
-                AssertPass(index, passed, entity);
-
-                if (m_dependentsLkp.TryGetBuffer(entity, out var deps))
+                if (HasWeLayout(entity))
                 {
-                    for (int i = 0; i < deps.Length; i++)
-                    {
-                        AssertPass(index, passed, deps[i].dependentEntity);
-                    }
+                    hasAnyWeLayout = true;
+                    AssertPass(index, passed, entity);
                 }
-            }
 
-            private void CatalogSubObjects(int index, Entity entity)
-            {
                 if (m_subObjectsLkp.TryGetBuffer(entity, out var subObjects) && !subObjects.IsEmpty)
                 {
-                    DynamicBuffer<WEDependantRendering> dependentsBuff = m_CommandBuffer.AddBuffer<WEDependantRendering>(index, entity);
-                    dependentsBuff.Clear();
                     for (int i = 0; i < subObjects.Length; i++)
                     {
-                        var subObj = subObjects[i].m_SubObject;
-                        var shallBeDep = m_CullInfoLkp.TryGetComponent(subObj, out var cullInfo) && (cullInfo.m_Mask & Game.Common.BoundsMask.NormalLayers) == 0 && (!m_meshesLkp.TryGetBuffer(subObj, out var buffSub) || buffSub.IsEmpty);
-                        if (shallBeDep)
+                        var subObject = subObjects[i].m_SubObject;
+                        var shallBeDependent =
+                            m_CullInfoLkp.TryGetComponent(subObject, out var subCullInfo)
+                            && (subCullInfo.m_Mask & Game.Common.BoundsMask.NormalLayers) == 0
+                            && (!m_meshesLkp.TryGetBuffer(subObject, out var subMeshes) || subMeshes.IsEmpty);
+
+                        if (shallBeDependent && HasWeLayout(subObject))
                         {
-                            dependentsBuff.Add(new WEDependantRendering { dependentEntity = subObj });
+                            hasAnyWeLayout = true;
+                            AssertPass(index, passed, subObject);
                         }
                     }
                 }
+
+                if (!hasAnyWeLayout) return;
             }
+
+            private bool HasWeLayout(Entity entity)
+            {
+                return (m_weTemplateForPrefabLookup.TryGetComponent(entity, out var prefabWeLayout) && prefabWeLayout.childEntity != Entity.Null)
+                    || (m_weSubRefLookup.TryGetBuffer(entity, out var subLayout) && subLayout.Length > 0);
+            }
+
+            private void CatalogSubObjects(int index, Entity entity) { }
 
             private void AssertPass(int index, bool passed, Entity entity)
             {
@@ -280,17 +274,6 @@ namespace BelzontWE
             {
                 if ((!m_weTemplateForPrefabLookup.TryGetComponent(entity, out var prefabWeLayout) || prefabWeLayout.childEntity == Entity.Null) & (!m_weSubRefLookup.TryGetBuffer(entity, out var subLayout) || subLayout.Length == 0)) return;
 
-                if (!m_WEDrawingLookup.HasEnabledComponent(entity))
-                {
-                    if (m_WEDrawingLookup.HasComponent(entity))
-                    {
-                        m_CommandBuffer.SetComponentEnabled<WEDrawing>(index, entity, true);
-                    }
-                    else
-                    {
-                        m_CommandBuffer.AddComponent<WEDrawing>(index, entity);
-                    }
-                }
 
                 if (m_geomEntitiesLastFrame.Contains(entity) && (entity.Index & WEConstants.RENDERER_FRAME_CHECK_MASK) != (frameCount & WEConstants.RENDERER_FRAME_CHECK_MASK) && (!isAtWeEditor || entity != m_selectedEntity))
                 {
@@ -339,13 +322,7 @@ namespace BelzontWE
                 }
             }
 
-            private void FailedCulling(Entity entity, int index)
-            {
-                if (m_WEDrawingLookup.HasEnabledComponent(entity))
-                {
-                    m_CommandBuffer.SetComponentEnabled<WEDrawing>(index, entity, false);
-                }
-            }
+            private void FailedCulling(Entity entity, int index) { }
 
             private unsafe void PopulateVars(Entity entity, ref FixedString512Bytes inheritableVars, out FixedString512Bytes localVars)
             {
@@ -396,30 +373,10 @@ namespace BelzontWE
                 {
                     case WESimulationTextType.Text:
                     case WESimulationTextType.Image:
-                        if (mesh.IsDirty() && !m_weWaitingRenderingLookup.HasEnabledComponent(nextEntity))
-                        {
-                            if (!m_weWaitingRenderingLookup.HasComponent(nextEntity))
-                            {
-                                m_CommandBuffer.AddComponent<WEWaitingRendering>(index, nextEntity);
-                            }
-                            else
-                            {
-                                m_CommandBuffer.SetComponentEnabled<WEWaitingRendering>(index, nextEntity, true);
-                            }
-                        }
+                        if (mesh.IsDirty() && m_weWaitingRenderingLookup.HasComponent(nextEntity) && !m_weWaitingRenderingLookup.HasEnabledComponent(nextEntity)) { m_CommandBuffer.SetComponentEnabled<WEWaitingRendering>(index, nextEntity, true); }
                         break;
                     case WESimulationTextType.Placeholder:
-                        if (mesh.IsTemplateDirty() && !m_weWaitingRenderingLookup.HasEnabledComponent(nextEntity))
-                        {
-                            if (!m_weWaitingRenderingLookup.HasComponent(nextEntity))
-                            {
-                                m_CommandBuffer.AddComponent<WEWaitingRendering>(index, nextEntity);
-                            }
-                            else
-                            {
-                                m_CommandBuffer.SetComponentEnabled<WEWaitingRendering>(index, nextEntity, true);
-                            }
-                        }
+                        if (mesh.IsTemplateDirty() && m_weWaitingRenderingLookup.HasComponent(nextEntity) && !m_weWaitingRenderingLookup.HasEnabledComponent(nextEntity)) { m_CommandBuffer.SetComponentEnabled<WEWaitingRendering>(index, nextEntity, true); }
                         return;
                 }
             }
@@ -429,22 +386,11 @@ namespace BelzontWE
                 if (nthCall >= 16) return;
                 if (!m_weMeshLookup.TryGetComponent(nextEntity, out var mesh))
                 {
-                    DestroyRecursive(ref this, nextEntity, unfilteredChunkIndex);
+                    return;
                     return;
                 }
                 var transform = m_weTransformLookup[nextEntity];
-                if (!m_weDirtyFormulae.HasComponent(nextEntity))
-                {
-                    // Need to make a copy here since we're modifying it
-                    var mutableVars = variables;
-                    PopulateVars(nextEntity, ref mutableVars, out FixedString512Bytes lclVars);
-                    m_CommandBuffer.AddComponent(unfilteredChunkIndex, nextEntity, new WETextDataDirtyFormulae
-                    {
-                        geometry = geometryEntity,
-                        vars = lclVars,
-                    });
-                    return;
-                }
+                if (!m_weDirtyFormulae.HasComponent(nextEntity)) return;
                 CheckMesh(ref mesh, nextEntity, unfilteredChunkIndex);
 
                 if (transform.useFormulaeToCheckIfDraw && !transform.MustDraw)
@@ -485,15 +431,7 @@ namespace BelzontWE
                         {
                             if (!m_weTemplateUpdaterLookup.TryGetBuffer(nextEntity, out var updaterBuff))
                             {
-                                if (m_weWaitingRenderingLookup.HasComponent(nextEntity))
-                                {
-
-                                    m_CommandBuffer.SetComponentEnabled<WEWaitingRendering>(unfilteredChunkIndex, nextEntity, true);
-                                }
-                                else
-                                {
-                                    m_CommandBuffer.AddComponent<WEWaitingRendering>(unfilteredChunkIndex, nextEntity);
-                                }
+                                if (m_weWaitingRenderingLookup.HasComponent(nextEntity)) { m_CommandBuffer.SetComponentEnabled<WEWaitingRendering>(unfilteredChunkIndex, nextEntity, true); }
                                 return;
                             }
 
@@ -621,38 +559,14 @@ namespace BelzontWE
                             var forceEditorRefresh = isAtWeEditor && nextEntity == m_selectedSubEntity;
                             if (forceEditorRefresh || CheckForUpdates(geometryEntity, nextEntity, unfilteredChunkIndex, in currentVars, 2000))
                             {
-                                var dirtyFormulae = new WETextDataDirtyFormulae { geometry = geometryEntity, vars = currentVars };
-                                if (m_weDirtyFormulae.HasComponent(nextEntity))
-                                {
-                                    m_CommandBuffer.SetComponent(unfilteredChunkIndex, nextEntity, dirtyFormulae);
-                                }
-                                else
-                                {
-                                    m_CommandBuffer.AddComponent(unfilteredChunkIndex, nextEntity, dirtyFormulae);
-                                }
-                                m_CommandBuffer.SetComponentEnabled<WETextDataDirtyFormulae>(unfilteredChunkIndex, nextEntity, true);
-                                var inheritedCache = new WEInheritedVarsCache { vars = inheritableVars };
-                                if (m_weInheritedVarsCacheLkp.HasComponent(nextEntity))
-                                {
-                                    m_CommandBuffer.SetComponent(unfilteredChunkIndex, nextEntity, inheritedCache);
-                                }
-                                else
-                                {
-                                    m_CommandBuffer.AddComponent(unfilteredChunkIndex, nextEntity, inheritedCache);
-                                }
+                                var dirtyFormulae = new WETextDataDirtyFormulae { geometry = geometryEntity, vars = currentVars }; if (!m_weDirtyFormulae.HasComponent(nextEntity)) return; m_CommandBuffer.SetComponent(unfilteredChunkIndex, nextEntity, dirtyFormulae); m_CommandBuffer.SetComponentEnabled<WETextDataDirtyFormulae>(unfilteredChunkIndex, nextEntity, true);
+                                var inheritedCache = new WEInheritedVarsCache { vars = inheritableVars }; if (m_weInheritedVarsCacheLkp.HasComponent(nextEntity)) { m_CommandBuffer.SetComponent(unfilteredChunkIndex, nextEntity, inheritedCache); }
                                 if (m_weSubObjectsLkp.TryGetBuffer(nextEntity, out var subObjBuf))
                                 {
                                     for (int si = 0; si < subObjBuf.Length; si++)
                                     {
                                         var subObjEntity = subObjBuf[si].m_SubObject;
-                                        if (m_weInheritedVarsCacheLkp.HasComponent(subObjEntity))
-                                        {
-                                            m_CommandBuffer.SetComponent(unfilteredChunkIndex, subObjEntity, new WEInheritedVarsCache { vars = inheritableVars });
-                                        }
-                                        else
-                                        {
-                                            m_CommandBuffer.AddComponent(unfilteredChunkIndex, subObjEntity, new WEInheritedVarsCache { vars = inheritableVars });
-                                        }
+                                        if (m_weInheritedVarsCacheLkp.HasComponent(subObjEntity)) { m_CommandBuffer.SetComponent(unfilteredChunkIndex, subObjEntity, new WEInheritedVarsCache { vars = inheritableVars }); }
                                     }
                                 }
                                 if (forceEditorRefresh)
@@ -673,15 +587,7 @@ namespace BelzontWE
                         {
                             if (m_weTemplateUpdaterLookup.HasBuffer(nextEntity))
                             {
-                                if (m_weWaitingRenderingLookup.HasComponent(nextEntity))
-                                {
-
-                                    m_CommandBuffer.SetComponentEnabled<WEWaitingRendering>(unfilteredChunkIndex, nextEntity, true);
-                                }
-                                else
-                                {
-                                    m_CommandBuffer.AddComponent<WEWaitingRendering>(unfilteredChunkIndex, nextEntity);
-                                }
+                                if (m_weWaitingRenderingLookup.HasComponent(nextEntity)) { m_CommandBuffer.SetComponentEnabled<WEWaitingRendering>(unfilteredChunkIndex, nextEntity, true); }
                                 return;
                             }
                             var scale = transform.scale;
@@ -773,6 +679,7 @@ namespace BelzontWE
             private bool CheckForUpdates(Entity geometryEntity, Entity nextEntity, int unfilteredChunkIndex, in FixedString512Bytes variables, int currentLod)
             {
                 if (minLodUpdateSetting > currentLod) return false;
+                if (!m_weDirtyFormulae.HasComponent(nextEntity)) return false;
                 if (m_weDirtyFormulae.HasEnabledComponent(nextEntity)) return false;
                 if (m_weMainLookup[nextEntity].nextUpdateFrame < frameCount)
                 {
@@ -834,32 +741,7 @@ namespace BelzontWE
                 return meshData.LastLod;
             }
 
-            private void DestroyRecursive(ref WERenderingJob job, Entity nextEntity, int unfilteredChunkIndex, Entity initialDelete = default)
-            {
-                if (nextEntity != initialDelete)
-                {
-                    if (initialDelete == default) initialDelete = nextEntity;
-                    if (job.m_weTemplateForPrefabLookup.TryGetComponent(nextEntity, out var data))
-                    {
-                        DestroyRecursive(ref job, data.childEntity, unfilteredChunkIndex, initialDelete);
-                    }
-                    if (job.m_weTemplateUpdaterLookup.TryGetBuffer(nextEntity, out var updater))
-                    {
-                        for (int j = 0; j < updater.Length; j++)
-                        {
-                            DestroyRecursive(ref job, updater[j].childEntity, unfilteredChunkIndex, initialDelete);
-                        }
-                    }
-                    if (job.m_weSubRefLookup.TryGetBuffer(nextEntity, out var subLayout))
-                    {
-                        for (int j = 0; j < subLayout.Length; j++)
-                        {
-                            DestroyRecursive(ref job, subLayout[j].m_weTextData, unfilteredChunkIndex, initialDelete);
-                        }
-                    }
-                }
-                job.m_CommandBuffer.AddComponent<Game.Common.Deleted>(unfilteredChunkIndex, nextEntity);
-            }
+            private void DestroyRecursive(ref WERenderingJob job, Entity nextEntity, int unfilteredChunkIndex, Entity initialDelete = default) { }
         }
 
 #if BURST

--- a/BelzontWE/Templates/WETemplateManager.EntityProcessing.cs
+++ b/BelzontWE/Templates/WETemplateManager.EntityProcessing.cs
@@ -10,6 +10,7 @@ namespace BelzontWE
     public partial class WETemplateManager
     {
         #region Entity Processing
+        private const int kMaxLayoutArrayInstancesPerFrame = 32;
         // Methods for processing entities in the main thread
 
 
@@ -59,8 +60,8 @@ namespace BelzontWE
         }
 
         /// <summary>
-        /// Updates placeholder layouts by instantiating template children
-        /// Handles array instancing with proper spacing and alignment.
+        /// Updates placeholder layouts by instantiating template children.
+        /// Handles array instancing incrementally so large saves do not flood EndFrameBarrier playback.
         /// </summary>
         internal void UpdateLayouts(NativeArray<Entity> entities)
         {
@@ -68,68 +69,132 @@ namespace BelzontWE
             var m_DataTransformLkp = GetComponentLookup<WETextDataTransform>();
             var m_subRefLkp = GetBufferLookup<WESubTextRef>();
             EntityCommandBuffer cmd = m_endFrameBarrier.CreateCommandBuffer();
-            for (int i = 0; i < entities.Length; i++)
+            var remainingFrameInstances = kMaxLayoutArrayInstancesPerFrame;
+
+            for (int i = 0; i < entities.Length && remainingFrameInstances > 0; i++)
             {
                 var e = entities[i];
                 if (e == Entity.Null) continue;
-                var buff = cmd.SetBuffer<WETemplateUpdater>(e);
+
                 var dataToBeProcessed = EntityManager.GetComponentData<WEPlaceholderToBeProcessedInMain>(e);
                 m_DataTransformLkp.TryGetComponent(e, out var transformData);
                 bool hasTemplate = TryGetTargetTemplate(dataToBeProcessed.layoutName, out WETextDataXmlTree targetTemplate);
-
-                for (int j = 0; j < buff.Length; j++)
+                if (!hasTemplate)
                 {
-                    cmd.DestroyEntity(buff[j].childEntity);
+                    ClearTemplateUpdaterBuffer(e, cmd);
+                    cmd.RemoveComponent<WEPlaceholderToBeProcessedInMain>(e);
+                    continue;
                 }
-                buff.Clear();
-                if (hasTemplate)
+
+                var registeredGuid = targetTemplate.Guid;
+                var targetSize = transformData.InstanceCountFn.EffectiveValue < 0
+                    ? math.clamp(transformData.ArrayInstancing.x * transformData.ArrayInstancing.y * transformData.ArrayInstancing.z, 1, 256)
+                    : math.clamp(transformData.InstanceCountFn.EffectiveValue, 0, 256);
+
+                if (targetSize == 0)
                 {
-                    var registeredGuid = targetTemplate.Guid;
-                    targetTemplate = targetTemplate.Clone();
+                    ClearTemplateUpdaterBuffer(e, cmd);
+                    cmd.RemoveComponent<WEPlaceholderToBeProcessedInMain>(e);
+                    continue;
+                }
 
-                    var targetSize = transformData.InstanceCountFn.EffectiveValue < 0 ? math.clamp(transformData.ArrayInstancing.x * transformData.ArrayInstancing.y * transformData.ArrayInstancing.z, 1, 256) : math.min(256, transformData.InstanceCountFn.EffectiveValue);
-                    if (targetSize == 0) goto end;
-                    var instancingCount = (uint3)math.min(transformData.InstanceCountByAxisOrder, math.ceil(targetSize / new float3(1, transformData.InstanceCountByAxisOrder[0], transformData.InstanceCountByAxisOrder[0] * transformData.InstanceCountByAxisOrder[1])));
-                    var spacingOffsets = transformData.SpacingByAxisOrder;
-                    var totalArea = (transformData.ArrayInstancing - 1) * transformData.arrayInstancingGapMeters.EffectiveValue;
+                var hasExistingBuffer = EntityManager.HasBuffer<WETemplateUpdater>(e);
+                var existingBuffer = hasExistingBuffer ? EntityManager.GetBuffer<WETemplateUpdater>(e, true) : default;
+                var existingCount = hasExistingBuffer ? existingBuffer.Length : 0;
+                var resetExisting = !hasExistingBuffer || existingCount > targetSize;
+                for (int j = 0; !resetExisting && j < existingCount; j++)
+                {
+                    var item = existingBuffer[j];
+                    resetExisting = item.templateEntity != registeredGuid || item.childEntity == Entity.Null || !EntityManager.Exists(item.childEntity);
+                }
 
-                    var effectivePivot = transformData.PivotAsFloat3 - (math.sign(totalArea.xyz) / 2) - .5f;
-
-                    var pivotOffset = effectivePivot * math.abs(totalArea);
-                    var alignmentByAxisOrder = transformData.AlignmentByAxisOrder;
-
-                    var spacingO = spacingOffsets[2];
-                    GetSpacingAndOffset(instancingCount.z, transformData.InstanceCountByAxisOrder.z, alignmentByAxisOrder.o, ref spacingO, out float3 offsetO);
-                    for (int o = 0; o < instancingCount.z; o++)
+                DynamicBuffer<WETemplateUpdater> buff;
+                if (resetExisting)
+                {
+                    buff = hasExistingBuffer ? cmd.SetBuffer<WETemplateUpdater>(e) : cmd.AddBuffer<WETemplateUpdater>(e);
+                    for (int j = 0; hasExistingBuffer && j < existingCount; j++)
                     {
-                        var spacingN = spacingOffsets[1];
-                        var effectiveCountN = (uint)math.min(math.ceil((targetSize - buff.Length) / (float)instancingCount.x), instancingCount.y);
-                        GetSpacingAndOffset(effectiveCountN, transformData.InstanceCountByAxisOrder.y, alignmentByAxisOrder.n, ref spacingN, out float3 offsetN);
-                        for (int n = 0; n < effectiveCountN; n++)
+                        var childEntity = existingBuffer[j].childEntity;
+                        if (childEntity != Entity.Null && EntityManager.Exists(childEntity)) cmd.DestroyEntity(childEntity);
+                    }
+                    existingCount = 0;
+                }
+                else
+                {
+                    if (existingCount >= targetSize)
+                    {
+                        cmd.RemoveComponent<WEPlaceholderToBeProcessedInMain>(e);
+                        continue;
+                    }
+                    buff = cmd.SetBuffer<WETemplateUpdater>(e);
+                    for (int j = 0; j < existingCount; j++) buff.Add(existingBuffer[j]);
+                }
+
+                targetTemplate = targetTemplate.Clone();
+                var instancingCount = (uint3)math.min(transformData.InstanceCountByAxisOrder, math.ceil(targetSize / new float3(1, transformData.InstanceCountByAxisOrder[0], transformData.InstanceCountByAxisOrder[0] * transformData.InstanceCountByAxisOrder[1])));
+                var spacingOffsets = transformData.SpacingByAxisOrder;
+                var totalArea = (transformData.ArrayInstancing - 1) * transformData.arrayInstancingGapMeters.EffectiveValue;
+                var effectivePivot = transformData.PivotAsFloat3 - (math.sign(totalArea.xyz) / 2) - .5f;
+                var pivotOffset = effectivePivot * math.abs(totalArea);
+                var alignmentByAxisOrder = transformData.AlignmentByAxisOrder;
+
+                var spacingO = spacingOffsets[2];
+                GetSpacingAndOffset(instancingCount.z, transformData.InstanceCountByAxisOrder.z, alignmentByAxisOrder.o, ref spacingO, out float3 offsetO);
+                var currentIndex = 0;
+
+                for (int o = 0; o < instancingCount.z && buff.Length < targetSize && remainingFrameInstances > 0; o++)
+                {
+                    var spacingN = spacingOffsets[1];
+                    var remainingInLayer = math.max(0, targetSize - (o * transformData.InstanceCountByAxisOrder.x * transformData.InstanceCountByAxisOrder.y));
+                    var effectiveCountN = (uint)math.min(math.ceil(remainingInLayer / (float)instancingCount.x), instancingCount.y);
+                    GetSpacingAndOffset(effectiveCountN, transformData.InstanceCountByAxisOrder.y, alignmentByAxisOrder.n, ref spacingN, out float3 offsetN);
+
+                    for (int n = 0; n < effectiveCountN && buff.Length < targetSize && remainingFrameInstances > 0; n++)
+                    {
+                        var spacingM = spacingOffsets[0];
+                        var rowStartIndex = (o * transformData.InstanceCountByAxisOrder.x * transformData.InstanceCountByAxisOrder.y) + (n * transformData.InstanceCountByAxisOrder.x);
+                        var effectiveCountM = (uint)math.min(targetSize - rowStartIndex, instancingCount.x);
+                        GetSpacingAndOffset(effectiveCountM, transformData.InstanceCountByAxisOrder.x, alignmentByAxisOrder.m, ref spacingM, out float3 offsetM);
+                        var totalOffset = pivotOffset + offsetM + offsetN + offsetO;
+
+                        for (int m = 0; m < effectiveCountM && buff.Length < targetSize && remainingFrameInstances > 0; m++)
                         {
-                            var spacingM = spacingOffsets[0];
-                            var effectiveCountM = (uint)math.min(targetSize - buff.Length, instancingCount.x);
-                            GetSpacingAndOffset(effectiveCountM, transformData.InstanceCountByAxisOrder.x, alignmentByAxisOrder.m, ref spacingM, out float3 offsetM);
-                            var totalOffset = pivotOffset + offsetM + offsetN + offsetO;
-                            for (int m = 0; m < effectiveCountM; m++)
+                            currentIndex = rowStartIndex + m;
+                            if (currentIndex < existingCount) continue;
+
+                            targetTemplate.self.transform.offsetPosition = (Vector3Xml)(Vector3)(totalOffset + (m * spacingM) + (n * spacingN) + (o * spacingO));
+                            targetTemplate.self.transform.pivot = transformData.pivot;
+
+                            var updater = new WETemplateUpdater()
                             {
-                                targetTemplate.self.transform.offsetPosition = (Vector3Xml)(Vector3)(totalOffset + (m * spacingM) + (n * spacingN) + (o * spacingO));
-                                targetTemplate.self.transform.pivot = transformData.pivot;
+                                templateEntity = registeredGuid,
+                                childEntity = WELayoutUtility.DoCreateLayoutItemCmdBuffer(true, targetTemplate.ModSource, targetTemplate, e, Entity.Null, ref m_MainDataLkp, ref m_subRefLkp, cmd, WELayoutUtility.ParentEntityMode.TARGET_IS_SELF_PARENT_HAS_TARGET)
+                            };
 
-                                var updater = new WETemplateUpdater()
-                                {
-                                    templateEntity = registeredGuid,
-                                    childEntity = WELayoutUtility.DoCreateLayoutItemCmdBuffer(true, targetTemplate.ModSource, targetTemplate, e, Entity.Null, ref m_MainDataLkp, ref m_subRefLkp, cmd, WELayoutUtility.ParentEntityMode.TARGET_IS_SELF_PARENT_HAS_TARGET)
-                                };
-
-                                buff.Add(updater);
-                                if (buff.Length >= targetSize) goto end;
-                            }
+                            buff.Add(updater);
+                            remainingFrameInstances--;
                         }
                     }
                 }
-            end:
-                cmd.RemoveComponent<WEPlaceholderToBeProcessedInMain>(e);
+
+                if (buff.Length >= targetSize)
+                {
+                    cmd.RemoveComponent<WEPlaceholderToBeProcessedInMain>(e);
+                }
+            }
+        }
+
+        private void ClearTemplateUpdaterBuffer(Entity e, EntityCommandBuffer cmd)
+        {
+            if (EntityManager.HasBuffer<WETemplateUpdater>(e))
+            {
+                var existingBuffer = EntityManager.GetBuffer<WETemplateUpdater>(e, true);
+                for (int j = 0; j < existingBuffer.Length; j++)
+                {
+                    var childEntity = existingBuffer[j].childEntity;
+                    if (childEntity != Entity.Null && EntityManager.Exists(childEntity)) cmd.DestroyEntity(childEntity);
+                }
+                cmd.SetBuffer<WETemplateUpdater>(e).Clear();
             }
         }
 

--- a/BelzontWE/Templates/WETemplateManager.cs
+++ b/BelzontWE/Templates/WETemplateManager.cs
@@ -39,7 +39,9 @@ namespace BelzontWE
         private EntityQuery m_prefabsToMarkDirty;
         private EntityQuery m_prefabsDataToSerialize;
         private Dictionary<long, WETextDataXmlTree> PrefabTemplates;
+        private const int kMaxSavedLayoutRootItemsPerFrame = 96;
         private readonly Queue<Action<EntityCommandBuffer>> m_executionQueue = new();
+        private readonly Queue<SavedLayoutRestoreTask> m_savedLayoutRestoreQueue = new();
         private bool m_templatesDirty;
         public Entity PrefabUpdateSource { get; private set; } = Entity.Null;
 
@@ -93,13 +95,7 @@ namespace BelzontWE
                 {
                     if (dataTree?.children?.Length > 0)
                     {
-                        var children = dataTree.children;
-                        m_executionQueue.Enqueue((cmd) =>
-                        {
-                            ComponentLookup<WETextDataMain> tdLookup = GetComponentLookup<WETextDataMain>();
-                            BufferLookup<WESubTextRef> subTextLookup = GetBufferLookup<WESubTextRef>();
-                            WELayoutUtility.DoCreateLayoutItemArray(false, null, children, key, key, ref tdLookup, ref subTextLookup, cmd);
-                        });
+                        m_savedLayoutRestoreQueue.Enqueue(new SavedLayoutRestoreTask(key, dataTree.children));
                     }
                 }
                 catch (Exception e)
@@ -257,23 +253,71 @@ namespace BelzontWE
 
         protected override void OnUpdate()
         {
-            if (GameManager.instance.isGameLoading || IsLoadingLayouts || !WriteEverywhereCS2Mod.IsInitializationComplete) return;
+            if (!WriteEverywhereCS2Mod.IsInitializationComplete) return;
+
+            ProcessSavedLayoutRestoreQueue();
+
+            if (GameManager.instance.isGameLoading) return;
 
             // Process execution queue for UI actions
             if (m_executionQueue.Count > 0)
             {
                 var cmdBuffer = m_endFrameBarrier.CreateCommandBuffer();
-                while (m_executionQueue.TryDequeue(out var nextAction))
+                if (m_executionQueue.TryDequeue(out var nextAction))
                 {
                     nextAction?.Invoke(cmdBuffer);
                 }
             }
 
             // Update prefab index dictionary (file I/O)
-            UpdatePrefabIndexDictionary();
+            if (!IsLoadingLayouts) UpdatePrefabIndexDictionary();
 
             // Note: Entity processing has been moved to WETemplateUpdateSystem
             Dependency.Complete();
+        }
+
+        private void ProcessSavedLayoutRestoreQueue()
+        {
+            if (m_savedLayoutRestoreQueue.Count == 0) return;
+
+            var cmdBuffer = m_endFrameBarrier.CreateCommandBuffer();
+            var tdLookup = GetComponentLookup<WETextDataMain>();
+            var subTextLookup = GetBufferLookup<WESubTextRef>();
+            var remainingItems = kMaxSavedLayoutRootItemsPerFrame;
+
+            while (remainingItems > 0 && m_savedLayoutRestoreQueue.TryDequeue(out var task))
+            {
+                if (task.TargetEntity == Entity.Null || !EntityManager.Exists(task.TargetEntity))
+                {
+                    continue;
+                }
+
+                if (task.Children is not { Length: > 0 } || task.NextChildIndex >= task.Children.Length)
+                {
+                    continue;
+                }
+                var restoredItems = WELayoutUtility.DoCreateLayoutItemArrayRange(false, null, task.Children, task.NextChildIndex, remainingItems, task.TargetEntity, task.TargetEntity, ref tdLookup, ref subTextLookup, cmdBuffer);
+                task.NextChildIndex += restoredItems;
+                remainingItems -= restoredItems;
+
+                if (task.NextChildIndex < task.Children.Length)
+                {
+                    m_savedLayoutRestoreQueue.Enqueue(task);
+                }
+            }
+        }
+
+        private sealed class SavedLayoutRestoreTask
+        {
+            public SavedLayoutRestoreTask(Entity targetEntity, WETextDataXmlTree[] children)
+            {
+                TargetEntity = targetEntity;
+                Children = children;
+            }
+
+            public Entity TargetEntity { get; }
+            public WETextDataXmlTree[] Children { get; }
+            public int NextChildIndex { get; set; }
         }
 
         public void SetDefaults(Context context)

--- a/BelzontWE/Utils/WELayoutUtility.cs
+++ b/BelzontWE/Utils/WELayoutUtility.cs
@@ -1,4 +1,4 @@
-﻿using BelzontWE.Utils;
+using BelzontWE.Utils;
 using Colossal.Entities;
 using Unity.Entities;
 using Unity.Mathematics;
@@ -43,6 +43,11 @@ namespace BelzontWE
             em.AddComponentData(newEntity, material);
             em.AddComponentData(newEntity, transform);
             em.AddComponent<WETextComponentValid>(newEntity);
+            em.AddComponent<WEWaitingRendering>(newEntity);
+            em.SetComponentEnabled<WEWaitingRendering>(newEntity, false);
+            em.AddComponentData(newEntity, new WETextDataDirtyFormulae());
+            em.SetComponentEnabled<WETextDataDirtyFormulae>(newEntity, false);
+            em.AddComponentData(newEntity, new WEInheritedVarsCache());
             if (childTargetMode == ParentEntityMode.TARGET_IS_TARGET)
             {
                 if (!GetReader(em).TryGetBuffer<WESubTextRef>(parentEntity, true, out var subRefBuff)) subRefBuff = em.AddBuffer<WESubTextRef>(parentEntity);
@@ -77,6 +82,20 @@ namespace BelzontWE
                 DoCreateLayoutItemCommandBuffer(fromTemplate, modSource, toCopy, parentEntity, targetEntity, ref tdLookup, ref subTextLookup, cmd, ref buff, childTargetMode);
             }
         }
+        public static int DoCreateLayoutItemArrayRange(bool fromTemplate, string modSource, WETextDataXmlTree[] toCopyArray, int startIndex, int maxItems, Entity parentEntity, Entity targetEntity, ref ComponentLookup<WETextDataMain> tdLookup,
+                   ref BufferLookup<WESubTextRef> subTextLookup, EntityCommandBuffer cmd,
+                   ParentEntityMode childTargetMode = ParentEntityMode.TARGET_IS_TARGET)
+        {
+            if (toCopyArray == null || startIndex >= toCopyArray.Length || maxItems <= 0) return 0;
+
+            if (!subTextLookup.TryGetBuffer(parentEntity, out var buff)) buff = childTargetMode == ParentEntityMode.TARGET_IS_TARGET ? cmd.AddBuffer<WESubTextRef>(parentEntity) : default;
+            var endIndex = math.min(toCopyArray.Length, startIndex + maxItems);
+            for (var i = startIndex; i < endIndex; i++)
+            {
+                DoCreateLayoutItemCommandBuffer(fromTemplate, modSource, toCopyArray[i], parentEntity, targetEntity, ref tdLookup, ref subTextLookup, cmd, ref buff, childTargetMode);
+            }
+            return endIndex - startIndex;
+        }
 
         private static Entity DoCreateLayoutItemCommandBuffer(bool fromTemplate, string modSource, WETextDataXmlTree toCopy, Entity parentEntity, Entity targetEntity, ref ComponentLookup<WETextDataMain> tdLookup,
         ref BufferLookup<WESubTextRef> subTextLookup, EntityCommandBuffer cmd,
@@ -89,6 +108,11 @@ namespace BelzontWE
             cmd.AddComponent(newEntity, material);
             cmd.AddComponent(newEntity, transform);
             cmd.AddComponent<WETextComponentValid>(newEntity);
+            cmd.AddComponent<WEWaitingRendering>(newEntity);
+            cmd.SetComponentEnabled<WEWaitingRendering>(newEntity, false);
+            cmd.AddComponent(newEntity, new WETextDataDirtyFormulae());
+            cmd.SetComponentEnabled<WETextDataDirtyFormulae>(newEntity, false);
+            cmd.AddComponent(newEntity, new WEInheritedVarsCache());
             var buffVars = cmd.AddBuffer<WETextDataVariable>(newEntity);
             if (toCopy.variables?.Length > 0)
             {


### PR DESCRIPTION
- avoid ECB overflow by pre-seeding rendering/formula/cache components on new WE entities

- restore dependent/subobject WE rendering without structural culling writes

- batch saved layout restoration and array instancing to reduce load spikes

- keep the loading path delayed per frame, which may need tuning for the final release